### PR TITLE
systemd environment variables file is absent if no variables are defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,6 +139,14 @@
   notify:
     - restart mongodb exporter
 
+- name: Ensure drop-in systemd file is absent if no environment variables are defined
+  file:
+    path: "{{ mongodb_exporter_env_file.dest }}"
+    state: absent
+  when: mongodb_exporter_env_vars |length == 0
+  notify:
+    - restart mongodb exporter
+
 - name: Create systemd service file
   template:
     src: mongodb_exporter.service.j2

--- a/templates/mongodb_exporter.service.j2
+++ b/templates/mongodb_exporter.service.j2
@@ -108,7 +108,7 @@ ExecStart={{ mongodb_exporter_bin_dir.dest }}/mongodb_exporter \
 	    {% endif %}
                 --log.level={{ mongodb_exporter_log_level }}
 
-SyslogIdentifier=mysqld_exporter
+SyslogIdentifier=mongodb_exporter
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Hi,

I cleared the systemd environment variables that I initially declared in my playbook, but the file and variables were still here because of `(when: mongodb_exporter_env_vars |length > 0)` test.

Maybe it can be usefull to integer a environment variables file deletion when no variables are declared, in order to obtain a fully declarative environment variables process ?

Regards