### PR TITLE
Add the possibility to select binary architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ An Ansible role which installs and configures Prometheus MongoDB Exporter by Per
 mongodb_exporter_version: 0.7.0
 # Exporter repository URL
 mongodb_exporter_base_url: https://github.com/percona/mongodb_exporter
+# Exporter binary architecture
+mongodb_exporter_arch: amd64
 # Exporter download URL
-mongodb_exporter_release_url: "{{ mongodb_exporter_base_url }}/releases/download/v{{ mongodb_exporter_version }}/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-amd64.tar.gz"
+mongodb_exporter_release_url: "{{ mongodb_exporter_base_url }}/releases/download/v{{ mongodb_exporter_version }}/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-{{ mongodb_exporter_arch }}.tar.gz"
 
 # OS user to run exporter under
 mongodb_exporter_system_user: mongodb_exporter

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,10 @@
 mongodb_exporter_version: 0.31.2
 # Exporter repository URL
 mongodb_exporter_base_url: https://github.com/percona/mongodb_exporter
+# Exporter binary architecture
+mongodb_exporter_arch: amd64
 # Exporter download URL
-mongodb_exporter_release_url: "{{ mongodb_exporter_base_url }}/releases/download/v{{ mongodb_exporter_version }}/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-amd64.tar.gz"
+mongodb_exporter_release_url: "{{ mongodb_exporter_base_url }}/releases/download/v{{ mongodb_exporter_version }}/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-{{ mongodb_exporter_arch }}.tar.gz"
 
 # OS user to run exporter under
 mongodb_exporter_system_user: mongodb_exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,14 +117,14 @@
 
 - name: stat binary file
   stat:
-    path: "/tmp/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-amd64/mongodb_exporter"
+    path: "/tmp/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-{{ mongodb_exporter_arch }}/mongodb_exporter"
   register: binary
 
 - name: Rename binary (version > 0.20.0)
   command:
     argv:
       - mv
-      - "/tmp/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-amd64/mongodb_exporter"
+      - "/tmp/mongodb_exporter-{{ mongodb_exporter_version }}.{{ ansible_system |lower }}-{{ mongodb_exporter_arch }}/mongodb_exporter"
       - "{{ mongodb_exporter_bin_dir.dest }}/mongodb_exporter"
   when: binary.stat.exists and (mongodb_exporter_version is version('0.20.0', '>'))
 


### PR DESCRIPTION
Add the possibility to select binary architecture.
Default architecture is still amd64

New variable: mongodb_exporter_arch (default to 'amd64')

Tested on Ubuntu 20.04 ARM64