### PR TITLE
Сreate user and group as system

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Add system groups
   group:
     name: "{{ item }}"
+    system: true
   with_items:
     - "{{ mongodb_exporter_system_groups }}"
 
@@ -21,6 +22,7 @@
     name: "{{ mongodb_exporter_system_user }}"
     groups: "{{ mongodb_exporter_system_groups }}"
     shell: "/usr/sbin/nologin"
+    system: true
     createhome: false
 
 - name: Ensure directories for binary and env file are present


### PR DESCRIPTION
Create user and group for exporter as system (service), so will not be affected by any user/group managing tools.